### PR TITLE
Add default options: `from:1_week_ago to:10_minutes_from_now`

### DIFF
--- a/spec/lita/handlers/count_spec.rb
+++ b/spec/lita/handlers/count_spec.rb
@@ -19,4 +19,8 @@ RSpec.describe Lita::Handlers::Regexcellent, :lita_handler => true do
       expect(replies.last).to eq "Found 0 results."
     end
   end
+
+  describe "#fetch_slack_message_history" do
+    it "will be tested"
+  end
 end


### PR DESCRIPTION
This also fixes the bug that occurs if only `from` is included.

Resolves https://github.com/yangez/lita-regexcellent/issues/7
Resolves https://github.com/yangez/lita-regexcellent/issues/6
Resolves https://github.com/yangez/lita-regexcellent/issues/5