### PR TITLE
Teach the bot friendlier language

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Counts the number of Slack messages that matches a regular expression in the cur
 To use, issue the command (where `lita` is your robots name):
 
 ```
-lita count /regex/ from:1_year_from_now to:today
+lita count /regex/ since:1_week_ago until:now
 => 12 results found.
 ```
 
-`from` and `to` are both optional.
+`since` and `until` are both optional. They default to the listed values.
 
 ## Running tests
 

--- a/lib/lita/handlers/regexcellent.rb
+++ b/lib/lita/handlers/regexcellent.rb
@@ -2,47 +2,52 @@ module Lita
   module Handlers
     class Regexcellent < Handler
       Lita.register_handler(self)
+      class InvalidTimeFormatError < StandardError; end
 
       DEFAULT_RANGE = {
-        since: Chronic.parse("1 week ago").utc.to_f,
-        until: Chronic.parse("10 minutes from now").utc.to_f,
+        since: "1 week ago",
+        until: "now"
       }
 
       route(
-        /^count\s+\/(.+)\/(.*)/i,
+        /^count\s+(\S+)(.*)/i,
         :count,
         :command => true,
         :help    => {
-          "count /REGEX/ from:1_week_ago to:10_minutes_from_now" => "Counts number of regex matches in channel. 'from' and 'to' are optional (defaults shown)"
+          "count REGEX since:1_week_ago until:now" => "Counts number of regex matches in channel. 'since' and 'until' are optional (defaults shown)"
         }
       )
 
       def count(response)
-        messages = fetch_slack_message_history(response)
+        oldest = time_string_for('since', response) || DEFAULT_RANGE[:since]
+        latest = time_string_for('until', response) || DEFAULT_RANGE[:until]
 
-        regex_string = response.matches.first.first
+        regex_string = response.matches.first.first.tr('/', '')
         regex = Regexp.new regex_string
 
-        count = messages.count{ |message| message.text.match regex }
-        response.reply("Found #{count} results.")
+        begin
+          messages = fetch_slack_message_history(response.room.id, oldest, latest)
+          count = messages.count{ |message| message.text.match regex }
+          response.reply("Found #{count} results for */#{regex_string}/* since *#{oldest}* until *#{latest}*.")
+        rescue InvalidTimeFormatError
+          response.reply("Couldn't understand `since:#{oldest.tr(" ", "_")} until:#{latest.tr(" ", "_")}`.")
+        end
       end
 
       protected
 
-      def fetch_slack_message_history(response)
+      def fetch_slack_message_history(room_id, oldest, latest)
         messages = []
 
-        oldest = timestamp_for('from', response) || DEFAULT_RANGE[:since]
-        latest = timestamp_for('to', response) || DEFAULT_RANGE[:until]
-
         loop do
-          history = slack_client.channels_history({
-            channel: response.room.id,
+          options = {
+            channel: room_id,
             count: 1000,
             inclusive: 0,
-            oldest: oldest,
-            latest: latest
-          })
+            oldest: string_to_timestamp(oldest),
+            latest: string_to_timestamp(latest)
+          }
+          history = slack_client.channels_history(options)
           messages.push(history.messages).flatten!
 
           if history.has_more
@@ -54,13 +59,20 @@ module Lita
         messages
       end
 
-      def timestamp_for(type, response)
-        raise "unknown timestamp type" unless %w(to from).include? type
+      def time_string_for(type, response)
+        raise "unknown time string type" unless %w(since until).include? type
         options_string = response.matches.last.last
         return unless options_string && options_string.length > 0
         time_string = options_string.match(/#{type}:(\S+)/)
-        time = Chronic.parse time_string.try(:captures).try(:first).try(:tr, "_", " ") if time_string
-        time.utc.to_f if time
+        time_string.captures.first.try(:tr, "_", " ") if time_string
+      end
+
+      def string_to_timestamp(time_string)
+        parsed_string = Chronic.parse(time_string)
+        fail InvalidTimeFormatError unless parsed_string
+
+        # slack API can only handle 6 digits, otherwise it bugs out
+        sprintf("%0.06f", parsed_string.utc.to_f)
       end
 
       def slack_client

--- a/spec/lita/handlers/count_spec.rb
+++ b/spec/lita/handlers/count_spec.rb
@@ -7,16 +7,25 @@ RSpec.describe Lita::Handlers::Regexcellent, :lita_handler => true do
   subject { described_class.new(robot) }
 
   describe "#count" do
+    let(:room) { double(Lita::Room, id: 1)}
     before do
       allow_any_instance_of(described_class).to receive(:fetch_slack_message_history).and_return([])
+      allow_any_instance_of(Lita::Response).to receive(:room).and_return(room)
     end
 
-    it { is_expected.to route("Lita count /regex/") }
-    it { is_expected.to route("Lita count /regex/ from:yesterday to:today") }
+    it { is_expected.to route("Lita count regex") }
+    it { is_expected.to route("Lita count regex since:yesterday until:today") }
 
     it "responds with a count" do
-      send_message("Lita count /regex/")
-      expect(replies.last).to eq "Found 0 results."
+      send_message("Lita count regex")
+      expect(replies.last).to match /Found 0 results for \*\/regex\/\* since \*1 week ago\* until \*now\*\./
+    end
+
+    context "when regex is formatted as /regex/" do
+      it "responds with a count" do
+        send_message("Lita count /regex/")
+        expect(replies.last).to match /Found 0 results for \*\/regex\/\* since \*1 week ago\* until \*now\*\./
+      end
     end
   end
 


### PR DESCRIPTION
* Also accept regex not surrounded by `/`
* List natural language query details in reply
* Use `since, until` (not `from, to`)

Resolves https://github.com/yangez/lita-regexcellent/issues/2
Resolves https://github.com/yangez/lita-regexcellent/issues/8