### PR TITLE
Fix asterisk display issue

### DIFF
--- a/lib/lita/handlers/regexcellent.rb
+++ b/lib/lita/handlers/regexcellent.rb
@@ -9,7 +9,7 @@ module Lita
         until: "now"
       }
       MESSAGES = {
-        found: "Found %{count} results for */%{regex_string}/* since *%{oldest}* until *%{latest}*.",
+        found: "Found %{count} results for `/%{regex_string}/` since *%{oldest}* until *%{latest}*.",
         invalid_time_format: "Couldn't understand `since:%{oldest} until:%{latest}`."
       }
 

--- a/spec/lita/handlers/regexcellent_spec.rb
+++ b/spec/lita/handlers/regexcellent_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Lita::Handlers::Regexcellent, :lita_handler => true do
 
     it "responds with a count" do
       send_message("Lita count regex")
-      expect(replies.last).to match /Found 0 results for \*\/regex\/\* since \*1 week ago\* until \*now\*\./
+      expect(replies.last).to match /Found 0 results for `\/regex\/` since \*1 week ago\* until \*now\*\./
     end
 
     context "when there are messages from itself" do
@@ -54,7 +54,7 @@ RSpec.describe Lita::Handlers::Regexcellent, :lita_handler => true do
     context "when regex is formatted as /regex/" do
       it "responds with a count" do
         send_message("lita count /regex/")
-        expect(replies.last).to match /Found 0 results for \*\/regex\/\* since \*1 week ago\* until \*now\*\./
+        expect(replies.last).to match /Found 0 results for `\/regex\/` since \*1 week ago\* until \*now\*\./
       end
     end
   end


### PR DESCRIPTION
When someone queries with a `*` as part of their regex, it messes
with Slack's text formatting. This patch changes the bolded regex
to code format instead.

Resolves #17.